### PR TITLE
Use LoginScreen Mobius loop for Android and Web

### DIFF
--- a/anystream-client-android/src/debug/kotlin/helper/FlipperProvider.kt
+++ b/anystream-client-android/src/debug/kotlin/helper/FlipperProvider.kt
@@ -1,3 +1,20 @@
+/**
+ * AnyStream
+ * Copyright (C) 2022 Amit Goel
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package helper
 
 import android.app.Application

--- a/anystream-client-android/src/main/kotlin/ui/LoginScreen.kt
+++ b/anystream-client-android/src/main/kotlin/ui/LoginScreen.kt
@@ -17,91 +17,71 @@
  */
 package anystream.android.ui
 
-import android.graphics.Bitmap
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Button
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.autofill.Autofill
-import androidx.compose.ui.autofill.AutofillNode
 import androidx.compose.ui.autofill.AutofillType
-import androidx.compose.ui.focus.FocusState
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalAutofill
-import androidx.compose.ui.platform.LocalAutofillTree
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import anystream.android.AppTopBar
 import anystream.android.AppTypography
+import anystream.android.ui.components.AutofillInput
+import anystream.android.ui.components.QrImage
+import anystream.android.ui.components.onFocusStateChanged
+import anystream.android.util.createLoopController
 import anystream.client.AnyStreamClient
-import anystream.client.SessionManager
-import anystream.models.api.PairingMessage
-import com.google.zxing.BarcodeFormat
-import com.google.zxing.qrcode.QRCodeWriter
-import io.ktor.client.plugins.*
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import java.net.InetAddress
-
+import anystream.ui.login.*
+import kt.mobius.android.AndroidLogger
+import kt.mobius.android.MobiusAndroid
+import kt.mobius.flow.FlowMobius
+import kt.mobius.functions.Consumer
 
 @Composable
 fun LoginScreen(
-    sessionManager: SessionManager,
-    onLoginCompleted: (client: AnyStreamClient, serverUrl: String) -> Unit,
-    modifier: Modifier = Modifier
+    client: AnyStreamClient,
+    routeToHome: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
+    val (modelState, eventConsumerState) = createLoopController {
+        val factory = FlowMobius.loop(
+            LoginScreenUpdate,
+            LoginScreenHandler.create(client, routeToHome)
+        )
+            .logger(AndroidLogger.tag("Login"))
+        MobiusAndroid.controller(factory, LoginScreenModel.create(), LoginScreenInit)
+    }
     Scaffold(
         topBar = { AppTopBar(client = null, backStack = null) },
         modifier = modifier
     ) { padding ->
-        FormBody(sessionManager, onLoginCompleted, padding)
+        FormBody(modelState, eventConsumerState, padding)
     }
 }
 
 @Composable
 private fun FormBody(
-    sessionManager: SessionManager,
-    onLoginCompleted: (client: AnyStreamClient, serverUrl: String) -> Unit,
+    modelState: MutableState<LoginScreenModel>,
+    eventConsumerState: MutableState<Consumer<LoginScreenEvent>>,
     paddingValues: PaddingValues
 ) {
-    val scope = rememberCoroutineScope()
-    var serverUrl by remember { mutableStateOf(TextFieldValue("")) }
-    var username by remember { mutableStateOf(TextFieldValue()) }
-    var password by remember { mutableStateOf(TextFieldValue()) }
-    var errorMessage by rememberSaveable { mutableStateOf<String?>(null) }
     val showStacked = LocalConfiguration.current.screenWidthDp < 800
-    val isServerUrlValid by produceState(false, serverUrl.text) {
-        delay(400)
-        value = if (serverUrl.text.run { isNotBlank() && length > 5 }) {
-            withContext(Dispatchers.IO) {
-                try {
-                    // TODO: Check if server is AnyStream instance
-                    InetAddress.getByName(serverUrl.text.substringAfter("://")).isReachable(10)
-                } catch (e: Throwable) {
-                    false
-                }
-            }
-        } else false
-    }
+    val model by remember { modelState }
+    val eventConsumer by remember { eventConsumerState }
     StackedOrSideBySide(stacked = showStacked) {
         Column(
             verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
@@ -111,25 +91,27 @@ private fun FormBody(
                 .padding(paddingValues)
         ) {
             OutlinedTextField(
-                value = serverUrl,
+                value = model.serverUrl,
                 placeholder = { Text(text = "Server Url") },
-                onValueChange = { serverUrl = it },
+                onValueChange = { eventConsumer.accept(LoginScreenEvent.OnServerUrlChanged(it)) },
+                readOnly = model.isInputLocked(),
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Uri,
                     imeAction = ImeAction.Next
                 ),
                 singleLine = true,
             )
-            Autofill(
+            AutofillInput(
                 autofillTypes = listOf(AutofillType.EmailAddress, AutofillType.Username),
-                onFill = { username = TextFieldValue(it) }
+                onFill = { eventConsumer.accept(LoginScreenEvent.OnUsernameChanged(it)) }
             ) { node ->
                 val autofill = LocalAutofill.current
                 OutlinedTextField(
-                    value = username,
+                    value = model.username,
                     placeholder = { Text(text = "Username") },
-                    onValueChange = { username = it },
+                    onValueChange = { eventConsumer.accept(LoginScreenEvent.OnUsernameChanged(it)) },
                     singleLine = true,
+                    readOnly = model.isInputLocked(),
                     keyboardOptions = KeyboardOptions(
                         keyboardType = KeyboardType.Text,
                         imeAction = ImeAction.Next
@@ -141,17 +123,18 @@ private fun FormBody(
                     },
                 )
             }
-            Autofill(
+            AutofillInput(
                 autofillTypes = listOf(AutofillType.Password),
-                onFill = { password = TextFieldValue(it) }
+                onFill = { eventConsumer.accept(LoginScreenEvent.OnPasswordChanged(it)) }
             ) { node ->
                 val autofill = LocalAutofill.current
                 OutlinedTextField(
-                    value = password,
+                    value = model.password,
                     placeholder = { Text(text = "Password") },
                     visualTransformation = PasswordVisualTransformation(),
-                    onValueChange = { password = it },
+                    onValueChange = { eventConsumer.accept(LoginScreenEvent.OnPasswordChanged(it)) },
                     singleLine = true,
+                    readOnly = model.isInputLocked(),
                     keyboardOptions = KeyboardOptions(
                         keyboardType = KeyboardType.Password,
                         imeAction = ImeAction.Go
@@ -164,31 +147,19 @@ private fun FormBody(
                 )
             }
 
-            errorMessage?.let { error ->
-                Text(text = error)
+            model.loginError?.let { error ->
+                Text(text = error.toString())
             }
 
             Button(onClick = {
-                scope.launch {
-                    try {
-                        val client = AnyStreamClient(
-                            serverUrl = serverUrl.text,
-                            sessionManager = sessionManager
-                        )
-                        client.login(username.text, password.text)
-                        onLoginCompleted(client, serverUrl.text)
-                    } catch (e: ClientRequestException) {
-                        e.printStackTrace()
-                        errorMessage = "${e.response.status}"
-                    }
-                }
+                eventConsumer.accept(LoginScreenEvent.OnLoginSubmit)
             }) {
                 Text(text = "Submit")
             }
         }
 
-        if (isServerUrlValid) {
-            DisplayPairingCode(serverUrl.text, sessionManager, onLoginCompleted)
+        model.pairingCode?.let { pairingCode ->
+            DisplayPairingCode(pairingCode)
         }
     }
 }
@@ -222,117 +193,20 @@ private fun StackedOrSideBySide(
 
 @Composable
 private fun DisplayPairingCode(
-    serverUrl: String,
-    sessionManager: SessionManager,
-    onLoginCompleted: (client: AnyStreamClient, serverUrl: String) -> Unit,
+    pairingCode: String
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-        val client = AnyStreamClient(
-            serverUrl = serverUrl,
-            sessionManager = sessionManager
+        Text(
+            text = "Pairing Code",
+            style = AppTypography.subtitle1
         )
-        val pairingCode by produceState<String?>(null) {
-            while (value == null) {
-                client.createPairingSession().collect { message ->
-                    when (message) {
-                        is PairingMessage.Started -> {
-                            value = message.pairingCode
-                        }
-                        is PairingMessage.Authorized -> {
-                            try {
-                                client.createPairedSession(value!!, message.secret)
-                                onLoginCompleted(
-                                    AnyStreamClient(
-                                        serverUrl,
-                                        sessionManager = sessionManager
-                                    ),
-                                    serverUrl
-                                )
-                            } catch (e: ClientRequestException) {
-                                e.printStackTrace()
-                            }
-                        }
-                        is PairingMessage.Failed -> {
-                            value = null
-                        }
-                        is PairingMessage.Idle -> Unit
-                    }
-                }
-            }
-        }
-
-        if (pairingCode != null) {
-            Text(
-                text = "Pairing Code",
-                style = AppTypography.subtitle1
-            )
-            Text(
-                text = "Scan with another device to login.",
-                style = AppTypography.subtitle2
-            )
-            QrImage(content = pairingCode!!)
-        }
-    }
-}
-
-@Composable
-fun QrImage(
-    content: String
-) {
-    val bitmap by produceState<Bitmap?>(null) {
-        val size = 500
-        val bitMatrix = QRCodeWriter()
-            .encode(content, BarcodeFormat.QR_CODE, size, size)
-        val w: Int = bitMatrix.width
-        val h: Int = bitMatrix.height
-        val pixels = IntArray(w * h)
-        for (y in 0 until h) {
-            val offset = y * w
-            for (x in 0 until w) {
-                pixels[offset + x] = if (bitMatrix.get(x, y)) {
-                    0xFF000000
-                } else {
-                    0xFFFFFFFF
-                }.toInt()
-            }
-        }
-        value = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888).apply {
-            setPixels(pixels, 0, size, 0, 0, w, h)
-        }
-    }
-
-    bitmap?.run {
-        Image(
-            bitmap = asImageBitmap(),
-            modifier = Modifier.size(250.dp),
-            contentDescription = null
+        Text(
+            text = "Scan with another device to login.",
+            style = AppTypography.subtitle2
         )
+        QrImage(content = pairingCode, Modifier.size(250.dp))
     }
-}
-
-@Composable
-private fun Autofill(
-    autofillTypes: List<AutofillType>,
-    onFill: ((String) -> Unit),
-    content: @Composable (AutofillNode) -> Unit
-) {
-    val autofillNode = AutofillNode(onFill = onFill, autofillTypes = autofillTypes)
-
-    val autofillTree = LocalAutofillTree.current
-    autofillTree += autofillNode
-
-    Box(
-        Modifier.onGloballyPositioned {
-            autofillNode.boundingBox = it.boundsInWindow()
-        }
-    ) {
-        content(autofillNode)
-    }
-}
-
-private fun Autofill.onFocusStateChanged(focusState: FocusState, node: AutofillNode) {
-    if (focusState.isFocused) requestAutofillForNode(node) else cancelAutofillForNode(node)
 }

--- a/anystream-client-android/src/main/kotlin/ui/components/AutofillInput.kt
+++ b/anystream-client-android/src/main/kotlin/ui/components/AutofillInput.kt
@@ -1,0 +1,53 @@
+/**
+ * AnyStream
+ * Copyright (C) 2022 Drew Carlson
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package anystream.android.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.Autofill
+import androidx.compose.ui.autofill.AutofillNode
+import androidx.compose.ui.autofill.AutofillType
+import androidx.compose.ui.focus.FocusState
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalAutofillTree
+
+@Composable
+fun AutofillInput(
+    autofillTypes: List<AutofillType>,
+    onFill: ((String) -> Unit),
+    content: @Composable (AutofillNode) -> Unit
+) {
+    val autofillNode = AutofillNode(onFill = onFill, autofillTypes = autofillTypes)
+
+    val autofillTree = LocalAutofillTree.current
+    autofillTree += autofillNode
+
+    Box(
+        Modifier.onGloballyPositioned {
+            autofillNode.boundingBox = it.boundsInWindow()
+        }
+    ) {
+        content(autofillNode)
+    }
+}
+
+fun Autofill.onFocusStateChanged(focusState: FocusState, node: AutofillNode) {
+    if (focusState.isFocused) requestAutofillForNode(node) else cancelAutofillForNode(node)
+}

--- a/anystream-client-android/src/main/kotlin/ui/components/QrImage.kt
+++ b/anystream-client-android/src/main/kotlin/ui/components/QrImage.kt
@@ -1,0 +1,65 @@
+/**
+ * AnyStream
+ * Copyright (C) 2022 Drew Carlson
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package anystream.android.ui.components
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.qrcode.QRCodeWriter
+
+
+@Composable
+fun QrImage(
+    content: String,
+    modifier: Modifier = Modifier,
+) {
+    val bitmap by produceState<Bitmap?>(null, content) {
+        val size = 500
+        val bitMatrix = QRCodeWriter()
+            .encode(content, BarcodeFormat.QR_CODE, size, size)
+        val w: Int = bitMatrix.width
+        val h: Int = bitMatrix.height
+        val pixels = IntArray(w * h)
+        for (y in 0 until h) {
+            val offset = y * w
+            for (x in 0 until w) {
+                pixels[offset + x] = if (bitMatrix.get(x, y)) {
+                    0xFF000000
+                } else {
+                    0xFFFFFFFF
+                }.toInt()
+            }
+        }
+        value = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888).apply {
+            setPixels(pixels, 0, size, 0, 0, w, h)
+        }
+    }
+
+    bitmap?.run {
+        Image(
+            bitmap = asImageBitmap(),
+            modifier = modifier,
+            contentDescription = null
+        )
+    }
+}

--- a/anystream-client-android/src/main/kotlin/util/ComposeMobiusLoop.kt
+++ b/anystream-client-android/src/main/kotlin/util/ComposeMobiusLoop.kt
@@ -1,0 +1,80 @@
+/**
+ * AnyStream
+ * Copyright (C) 2022 Drew Carlson
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package anystream.android.util
+
+import android.content.ContextWrapper
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.*
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import kt.mobius.Connection
+import kt.mobius.MobiusLoop
+import kt.mobius.extras.QueuedConsumer
+import kt.mobius.functions.Consumer
+
+@Composable
+fun <M, E> createLoopController(
+    loopBuilder: () -> MobiusLoop.Controller<M, E>
+): Pair<MutableState<M>, MutableState<Consumer<E>>> {
+    val controller = remember { loopBuilder() }
+    val modelState = remember { mutableStateOf(controller.model) }
+    val eventConsumer = remember { mutableStateOf<Consumer<E>>(QueuedConsumer()) }
+
+    val currentContext = LocalContext.current
+    val activity = remember(currentContext) {
+        val activity = (currentContext as? ComponentActivity)
+            ?: ((currentContext as? ContextWrapper)?.baseContext as? ComponentActivity)
+        checkNotNull(activity)
+    }
+    DisposableEffect(controller) {
+        controller.connect { output ->
+            (eventConsumer.value as? QueuedConsumer<E>)?.dequeueAll(output)
+            eventConsumer.value = output
+            object : Connection<M> {
+                override fun accept(value: M) {
+                    modelState.value = value
+                }
+
+                override fun dispose() {
+                    eventConsumer.value = QueuedConsumer()
+                }
+            }
+        }
+        val observer = object : DefaultLifecycleObserver {
+            override fun onResume(owner: LifecycleOwner) {
+                if (!controller.isRunning) controller.start()
+                modelState.value = controller.model
+            }
+
+            override fun onPause(owner: LifecycleOwner) {
+                if (controller.isRunning) controller.stop()
+            }
+        }
+        activity.lifecycle.addObserver(observer)
+
+        onDispose {
+            activity.lifecycle.removeObserver(observer)
+            if (controller.isRunning) {
+                controller.stop()
+            }
+            controller.disconnect()
+        }
+    }
+    return Pair(modelState, eventConsumer)
+}

--- a/anystream-client-api/build.gradle.kts
+++ b/anystream-client-api/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     kotlin("plugin.serialization")
 }
 
+apply(plugin = "kotlinx-atomicfu")
+
 kotlin {
     jvm()
     js(IR) {
@@ -26,6 +28,7 @@ kotlin {
             kotlin.srcDirs("src")
             dependencies {
                 implementation(projects.anystreamDataModels)
+                implementation(libs.atomicfu)
                 implementation(libs.coroutines.core)
                 implementation(libs.serialization.core)
                 implementation(libs.serialization.json)

--- a/anystream-client-api/src/SessionManager.kt
+++ b/anystream-client-api/src/SessionManager.kt
@@ -29,6 +29,7 @@ import kotlin.native.concurrent.SharedImmutable
 private const val STORAGE_KEY = "SESSION_TOKEN"
 private const val PERMISSIONS_KEY = "PERMISSIONS_KEY"
 private const val USER_KEY = "USER_KEY"
+private const val SERVER_URL_KEY = "SERVER_URL_KEY"
 
 @SharedImmutable
 private val json = Json {
@@ -73,6 +74,10 @@ class SessionManager(private val dataStore: SessionDataStore) {
         fetchPermissions()
     }
 
+    fun writeServerUrl(serverUrl: String) {
+        dataStore.write(SERVER_URL_KEY, serverUrl)
+    }
+
     fun writeUser(user: User) {
         dataStore.write(USER_KEY, json.encodeToString(user))
         this.user.tryEmit(user)
@@ -86,6 +91,10 @@ class SessionManager(private val dataStore: SessionDataStore) {
     fun writePermissions(permissions: Set<String>) {
         dataStore.write(PERMISSIONS_KEY, permissions.joinToString(","))
         this.permissions.tryEmit(permissions)
+    }
+
+    fun fetchServerUrl(): String? {
+        return dataStore.read(SERVER_URL_KEY)
     }
 
     fun fetchUser(): User? {

--- a/anystream-client-core/src/commonMain/kotlin/anystream/ui/login/LoginScreenEffect.kt
+++ b/anystream-client-core/src/commonMain/kotlin/anystream/ui/login/LoginScreenEffect.kt
@@ -1,3 +1,20 @@
+/**
+ * AnyStream
+ * Copyright (C) 2022 Drew Carlson
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package anystream.ui.login
 
 sealed class LoginScreenEffect {

--- a/anystream-client-core/src/commonMain/kotlin/anystream/ui/login/LoginScreenEvent.kt
+++ b/anystream-client-core/src/commonMain/kotlin/anystream/ui/login/LoginScreenEvent.kt
@@ -1,3 +1,20 @@
+/**
+ * AnyStream
+ * Copyright (C) 2022 Drew Carlson
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package anystream.ui.login
 
 import anystream.models.User

--- a/anystream-client-core/src/commonMain/kotlin/anystream/ui/login/LoginScreenInit.kt
+++ b/anystream-client-core/src/commonMain/kotlin/anystream/ui/login/LoginScreenInit.kt
@@ -1,3 +1,20 @@
+/**
+ * AnyStream
+ * Copyright (C) 2022 Drew Carlson
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package anystream.ui.login
 
 import anystream.ui.login.LoginScreenModel.ServerValidation
@@ -14,7 +31,7 @@ object LoginScreenInit : Init<LoginScreenModel, LoginScreenEffect> {
             effects.add(LoginScreenEffect.PairingSession(model.serverUrl))
         }
 
-        if (model.serverUrl.isNotBlank() && model.serverValidation == ServerValidation.CHECKING) {
+        if (model.serverUrl.isNotBlank() && model.serverValidation == ServerValidation.VALIDATING) {
             effects.add(LoginScreenEffect.ValidateServerUrl(model.serverUrl))
         }
 

--- a/anystream-client-core/src/commonMain/kotlin/anystream/ui/login/LoginScreenModel.kt
+++ b/anystream-client-core/src/commonMain/kotlin/anystream/ui/login/LoginScreenModel.kt
@@ -1,3 +1,20 @@
+/**
+ * AnyStream
+ * Copyright (C) 2022 Drew Carlson
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package anystream.ui.login
 
 import anystream.models.api.CreateSessionError
@@ -14,7 +31,7 @@ data class LoginScreenModel(
     val supportsPairing: Boolean = true,
     val pairingCode: String? = null,
     val state: State = State.IDLE,
-    val serverValidation: ServerValidation = ServerValidation.CHECKING,
+    val serverValidation: ServerValidation = ServerValidation.VALIDATING,
     val loginError: CreateSessionError? = null,
 ) {
     enum class State {
@@ -22,7 +39,7 @@ data class LoginScreenModel(
     }
 
     enum class ServerValidation {
-        VALID, INVALID, CHECKING,
+        VALID, INVALID, VALIDATING,
     }
 
     fun credentialsAreSet(): Boolean {
@@ -33,13 +50,20 @@ data class LoginScreenModel(
         return serverValidation == ServerValidation.VALID
     }
 
+    fun isInputLocked(): Boolean {
+        return state != State.IDLE
+    }
+
     companion object {
         fun create(): LoginScreenModel {
             return LoginScreenModel()
         }
 
         fun create(serverUrl: String): LoginScreenModel {
-            return LoginScreenModel(serverUrl = serverUrl)
+            return LoginScreenModel(
+                serverUrl = serverUrl,
+                serverValidation = ServerValidation.VALID
+            )
         }
     }
 }

--- a/anystream-client-core/src/commonMain/kotlin/anystream/ui/login/LoginScreenUpdate.kt
+++ b/anystream-client-core/src/commonMain/kotlin/anystream/ui/login/LoginScreenUpdate.kt
@@ -1,3 +1,20 @@
+/**
+ * AnyStream
+ * Copyright (C) 2022 Drew Carlson
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package anystream.ui.login
 
 import anystream.ui.login.LoginScreenModel.ServerValidation
@@ -29,7 +46,7 @@ object LoginScreenUpdate : LoginScreenUpdateSpec {
             State.IDLE -> next(
                 model.copy(
                     serverUrl = event.serverUrl,
-                    serverValidation = ServerValidation.CHECKING,
+                    serverValidation = ServerValidation.VALIDATING,
                     pairingCode = null,
                 ),
                 LoginScreenEffect.ValidateServerUrl(serverUrl = event.serverUrl),
@@ -110,10 +127,12 @@ object LoginScreenUpdate : LoginScreenUpdateSpec {
         return when (model.state) {
             State.IDLE -> {
                 if (model.serverUrl == event.serverUrl) {
-                    next(
-                        model.copy(serverValidation = event.result),
-                        LoginScreenEffect.PairingSession(model.serverUrl)
-                    )
+                    val newModel = model.copy(serverValidation = event.result)
+                    if (event.result == ServerValidation.VALID) {
+                        next(newModel, LoginScreenEffect.PairingSession(event.serverUrl))
+                    } else {
+                        next(newModel)
+                    }
                 } else noChange()
             }
             else -> noChange()

--- a/anystream-client-core/src/commonTest/kotlin/anystream/ui/login/LoginScreenLoopTests.kt
+++ b/anystream-client-core/src/commonTest/kotlin/anystream/ui/login/LoginScreenLoopTests.kt
@@ -1,3 +1,20 @@
+/**
+ * AnyStream
+ * Copyright (C) 2022 Drew Carlson
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package anystream.ui.login
 
 import anystream.ui.login.LoginScreenModel.ServerValidation
@@ -22,7 +39,7 @@ class LoginScreenLoopTests {
                     hasModel(
                         defaultModel.copy(
                             serverUrl = testServerUrl,
-                            serverValidation = ServerValidation.CHECKING
+                            serverValidation = ServerValidation.VALIDATING
                         )
                     ),
                     hasEffects(

--- a/anystream-client-web/src/jsMain/kotlin/util/ComposeMobiusLoop.kt
+++ b/anystream-client-web/src/jsMain/kotlin/util/ComposeMobiusLoop.kt
@@ -1,0 +1,56 @@
+/**
+ * AnyStream
+ * Copyright (C) 2022 Drew Carlson
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package anystream.frontend.util
+
+import androidx.compose.runtime.*
+import kt.mobius.Connection
+import kt.mobius.MobiusLoop
+import kt.mobius.extras.QueuedConsumer
+import kt.mobius.functions.Consumer
+
+@Composable
+fun <M, E> createLoopController(
+    loopBuilder: () -> MobiusLoop.Controller<M, E>
+): Pair<MutableState<M>, MutableState<Consumer<E>>> {
+    val controller = remember { loopBuilder() }
+    val modelState = remember { mutableStateOf(controller.model) }
+    val eventConsumer = remember { mutableStateOf<Consumer<E>>(QueuedConsumer()) }
+
+    DisposableEffect(controller) {
+        controller.connect { output ->
+            (eventConsumer.value as? QueuedConsumer<E>)?.dequeueAll(output)
+            eventConsumer.value = output
+            object : Connection<M> {
+                override fun accept(value: M) {
+                    modelState.value = value
+                }
+
+                override fun dispose() {
+                    eventConsumer.value = QueuedConsumer()
+                }
+            }
+        }
+        controller.start()
+
+        onDispose {
+            controller.stop()
+            controller.disconnect()
+        }
+    }
+    return Pair(modelState, eventConsumer)
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,8 @@ buildscript {
         google()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.0.4")
+        classpath(libs.agp)
+        classpath(libs.atomicfu.plugin)
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,10 +6,11 @@ ktorio = "2.0.0-beta-1"
 composejb = "1.0.1"
 kotlinjs_ext = "1.0.1-pre.276-kotlin-1.6.0"
 ksp = "1.6.10-1.0.2"
+atomicfu = "0.17.0"
 
 qbittorrent = "0.4.0"
 torrent_search = "0.2.0"
-mobiuskt = "0.5.0"
+mobiuskt = "0.5.1"
 ktor_perm = "0.2.0"
 
 kmongo = "4.4.0"
@@ -25,6 +26,7 @@ compose = "1.1.0-rc01"
 composeCompiler = "1.1.0-rc02"
 exoplayer = "2.16.1"
 ax_runner = "1.4.0"
+agp = "7.0.4"
 
 okhttp = "4.9.3"
 
@@ -45,6 +47,11 @@ coroutines-jdk8 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8", ve
 
 serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "serialization" }
 serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
+
+atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
+atomicfu-plugin = { module = "org.jetbrains.kotlinx:atomicfu-gradle-plugin", version.ref = "atomicfu" }
+
+agp = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 
 kotlinjs-extensions = { module = "org.jetbrains.kotlin-wrappers:kotlin-extensions", version.ref = "kotlinjs_ext" }
 
@@ -126,7 +133,6 @@ flipperSo = { module = "com.facebook.soloader:soloader", version = "0.10.1" }
 mobiuskt-core = { module = "org.drewcarlson:mobiuskt-core", version.ref = "mobiuskt" }
 mobiuskt-test = { module = "org.drewcarlson:mobiuskt-test", version.ref = "mobiuskt" }
 mobiuskt-extras = { module = "org.drewcarlson:mobiuskt-extras", version.ref = "mobiuskt" }
-mobiuskt-android = { module = "org.drewcarlson:mobiuskt-android", version.ref = "mobiuskt" }
 mobiuskt-coroutines = { module = "org.drewcarlson:mobiuskt-coroutines", version.ref = "mobiuskt" }
 mobiuskt-updateSpec = { module = "org.drewcarlson:mobiuskt-update-spec", version.ref = "mobiuskt" }
 mobiuskt-updateSpec-api = { module = "org.drewcarlson:mobiuskt-update-spec-api", version.ref = "mobiuskt" }


### PR DESCRIPTION
- Adds `createLoopController` helper for Web and Android to bind the Mobius loop to Compose/Activity lifecycles
- Add missing file license headers
- Various cleanup/finalization in LoginScreen loop components
- Android: Move `AutofillInput` and `QrImage` composables to components subpackage
- Store configured serverUrl in `SessionManager` within the `AnyStreamClient`
- Refactor `AnyStreamClient` to support changing the Server Url at runtime, simplifying initial setup on and making the `serverUrl` storage a common code detail

@AmitGoelNYC No pressure to review, just wanted to share the important bit here which is hooking up the mobius loop to a screen composable.